### PR TITLE
feat: add restriction to merge anything but develop into main

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,14 +11,28 @@ jobs:
     name: branch-name-policy
     runs-on: ubuntu-latest
     steps:
-      - name: Allow only feature/* or fix/*
+      - name: Check branch naming and source policy
         run: |
-          echo "PR head ref: ${{ github.head_ref }}"
-          if [[ "${{ github.head_ref }}" != feature/* && "${{ github.head_ref }}" != fix/* ]]; then
-            echo "❌ Branch name must start with feature/ or fix/"
-            exit 1
+          TARGET_BRANCH="${{ github.base_ref }}"
+          SOURCE_BRANCH="${{ github.head_ref }}"
+
+          echo "Target branch: $TARGET_BRANCH"
+          echo "Source branch: $SOURCE_BRANCH"
+
+          if [[ "$TARGET_BRANCH" == "main" ]]; then
+            if [[ "$SOURCE_BRANCH" != "develop" ]]; then
+              echo "❌ Error: Only 'develop' can be merged into 'main'."
+              exit 1
+            fi
+            echo "✅ Main target check passed"
+
+          elif [[ "$TARGET_BRANCH" == "develop" ]]; then
+            if [[ "$SOURCE_BRANCH" != feature/* && "$SOURCE_BRANCH" != fix/* ]]; then
+              echo "❌ Error: Branch name must start with feature/ or fix/ when targeting develop."
+              exit 1
+            fi
+            echo "✅ Develop target check passed"
           fi
-          echo "✅ Branch name OK"
 
   lint:
     name: lint


### PR DESCRIPTION
## Description
Now only develop branch can be merged into main.

---

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [x] CI/CD / Configuration
- [ ] Documentation

---

## Checklist
- [x] Branch name follows `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
    > Example: ```feature/12-ci-branch-protection```
- [ ] Lint, tests, and build pass
- [ ] Preview deployment works


## Additional notes
