### PR TITLE
feat: implement persistent pagination state for Garage view

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,17 @@
+interface AppState {
+  garagePage: number;
+  winnersPage: number;
+}
+
+const state: AppState = {
+  garagePage: 1,
+  winnersPage: 1,
+};
+
+export default state;
+
+export const setGaragePage = (page: number) => {
+  state.garagePage = page;
+};
+
+export const getGaragePage = () => state.garagePage;

--- a/src/views/garage/garage-view.ts
+++ b/src/views/garage/garage-view.ts
@@ -4,6 +4,7 @@ import { CarsList } from "../../components/cars-list";
 import { CarForm } from "../../components/car-form";
 import { Button } from "../../components/ui/button";
 import { generateCars } from "../../utils/generate-cars";
+import state from '../../store';
 
 const CARS_PER_PAGE = 7;
 const GENERATE_CARS_COUNT = 100;
@@ -11,7 +12,7 @@ const GENERATE_CARS_COUNT = 100;
 export class GarageView extends BaseComponent {
   private carForm: CarForm;
   private generate100CarsBtn: Button;
-  private page = 1;
+  private page: number;
   private totalCount = 0;
   private totalPages = 0;
 
@@ -27,6 +28,7 @@ export class GarageView extends BaseComponent {
 
     this.prevBtn.textContent = "Prev";
     this.nextBtn.textContent = "Next";
+    this.page = state.garagePage;
 
     this.prevBtn.addEventListener(
       "click",
@@ -53,14 +55,14 @@ export class GarageView extends BaseComponent {
       this.nextBtn,
       this.carsList.getElement(),
     );
-    void this.loadPage(1);
+    void this.loadPage(this.page);
   }
 
   private async loadPage(page: number): Promise<void> {
     const { cars, totalCount } = await getCars(page);
 
     this.page = page;
-
+    state.garagePage = this.page;
     this.totalCount = Number(totalCount) || 0;
     this.totalPages = Math.max(1, Math.ceil(this.totalCount / CARS_PER_PAGE));
     this.titleEl.textContent = `Garage ${totalCount}`;


### PR DESCRIPTION
- Created central store for state management
- Integrated GarageView with store to persist page number
- Fixed view initialization to prevent state reset on re-render
- Updated page loading logic to sync with store

## Related Issue
Closes #19 

> Link this Pull Request to a GitHub Issue from the Project board.
> Use `Closes #<issue-number>` to automatically close the task after merge.

---

## Description
What does this PR change?

Implemented a centralized state management system to ensure that the user's current page in the Garage view is preserved when navigating between different sections of the application (e.g., switching to the Winners view and back).
---

## Type of change
- [x] Store Module: Created src/store/index.ts to hold the global application state, including garagePage and winnersPage.
- [x] GarageView Initialization: Modified the constructor to initialize this.page from the store instead of defaulting to 1.
- [x] State Sync: Updated loadPage in GarageView to save the current page to the store whenever a user navigates or the page updates.
- [x] No Reset on Render: Replaced the hardcoded loadPage(1) call with loadPage(this.page) to ensure the view renders with the persisted state upon component instantiation.
---

## Checklist
- [x] Switching Garage ⇄ Winners keeps current page for Garage view.
- [x] No full re-render that resets the state.
- [x] State is stored in a dedicated module (store).


## Additional notes
