### PR TITLE
feat: implement winners table with data enrichment and persistent state

### DIFF
--- a/src/api/garage.ts
+++ b/src/api/garage.ts
@@ -56,3 +56,8 @@ export const deleteCar = async (id: number) => {
     throw new Error(`Failed to delete car (${response.status})`);
   }
 };
+
+export const getCar = async (id: number): Promise<{ name: string; color: string; id: number }> => {
+  const response = await fetch(`${BASE_URL}/garage/${id}`);
+  return response.json();
+};

--- a/src/api/winners.ts
+++ b/src/api/winners.ts
@@ -1,16 +1,23 @@
-const BASE_URL = 'http://127.0.0.1:3000';
-export const WINNERS_PER_PAGE = 10; 
+const BASE_URL = "http://127.0.0.1:3000";
+export const WINNERS_PER_PAGE = 10;
 
 export interface WinnersResponse {
   winners: Array<{ id: number; wins: number; time: number }>;
   totalCount: string;
 }
 
-export const getWinners = async (page: number, limit: number = WINNERS_PER_PAGE): Promise<WinnersResponse> => {
-  const response = await fetch(`${BASE_URL}/winners?_page=${page}&_limit=${limit}`);
-  
+export const getWinners = async (
+  page: number,
+  limit: number = WINNERS_PER_PAGE,
+  sort: string = "id",
+  order: string = "ASC"
+): Promise<WinnersResponse> => {
+  const response = await fetch(
+    `${BASE_URL}/winners?_page=${page}&_limit=${limit}&_sort=${sort}&_order=${order}`
+  );
+
   return {
     winners: await response.json(),
-    totalCount: response.headers.get('X-Total-Count') || '0',
+    totalCount: response.headers.get("X-Total-Count") || "0",
   };
 };

--- a/src/components/header.ts
+++ b/src/components/header.ts
@@ -1,6 +1,7 @@
 import { BaseComponent } from "./ui/base-component";
 import { Button } from "./ui/button";
 import "./header.css";
+
 export class Header extends BaseComponent {
   constructor(onViewChange: (view: "garage" | "winners") => void) {
     super("header", "app-header");

--- a/src/views/winners/index.css
+++ b/src/views/winners/index.css
@@ -1,0 +1,45 @@
+.winners-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #121212;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+    text-align: start;
+  }
+  
+  .winners-table th {
+    background: #1f1f1f;
+    color: #ffffff;
+    padding: 16px;
+    text-align: left;
+    border-bottom: 2px solid #333;
+  }
+  
+  .winners-table th.sortable {
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  
+  .winners-table th.sortable:hover {
+    background: #2a2a2a;
+    cursor: pointer;
+  }
+  
+  .winners-table td {
+    padding: 12px 16px;
+    border-bottom: 1px solid #2222227e;
+    color: #e0e0e0;
+  }
+  
+  .winners-table tr:hover td {
+    background: rgba(66, 63, 63, 0.03);
+  }
+
+  .pagination-btns{
+    margin: 16px 0;
+    display: flex;
+    gap: 6px;
+    justify-content: center;
+    align-items: center;
+  }

--- a/src/views/winners/winners-view.ts
+++ b/src/views/winners/winners-view.ts
@@ -1,18 +1,171 @@
-import { BaseComponent } from '../../components/ui/base-component';
-import { getWinners } from '../../api/winners';
+import { BaseComponent } from "../../components/ui/base-component";
+import { Button } from "../../components/ui/button";
+import { CarIcon } from "../../components/ui/car-icon";
+import { getWinners, WINNERS_PER_PAGE } from "../../api/winners";
+import { getCar } from "../../api/garage";
+import state from "../../store";
+import "./index.css";
+
+const PAGE_NEXT = 1;
+const PAGE_PREV = -1;
+
+interface WinnerWithDetails {
+  id: number;
+  wins: number;
+  time: number;
+  car: { name: string; color: string };
+}
 
 export class WinnersView extends BaseComponent {
+  private titleEl = document.createElement("h1");
+  private pageEl = document.createElement("h2");
+  private tableContainer = document.createElement("div");
+  private paginationContainer = document.createElement("div");
+
+  private sortBy: "id" | "wins" | "time" = "id";
+  private sortOrder: "ASC" | "DESC" = "ASC";
+  private totalCount = 0;
+
+  private prevBtn: Button;
+  private nextBtn: Button;
+
   constructor() {
-    super('div', 'winners-view');
-    this.render();
+    super("div", "winners-view");
+    this.paginationContainer.className = "pagination-btns";
+
+    this.prevBtn = new Button("PREV", "nav-btn", "button", () =>
+      this.handlePageChange(PAGE_PREV)
+    );
+    this.nextBtn = new Button("NEXT", "nav-btn", "button", () =>
+      this.handlePageChange(PAGE_NEXT)
+    );
+
+    this.element.append(
+      this.titleEl,
+      this.pageEl,
+      this.tableContainer,
+      this.paginationContainer
+    );
+
+    this.paginationContainer.append(
+      this.prevBtn.getElement(),
+      this.nextBtn.getElement()
+    );
+
+    void this.loadData();
   }
 
-  private async render(): Promise<void> {
-    const { totalCount } = await getWinners(1);
+  private async loadData(): Promise<void> {
+    const page = state.winnersPage;
+    const { winners, totalCount } = await getWinners(
+      page,
+      WINNERS_PER_PAGE,
+      this.sortBy,
+      this.sortOrder
+    );
+    this.totalCount = Number(totalCount);
 
-    this.element.innerHTML = `
-      <h1>Winners (${totalCount})</h1>
-      <h2>Page #1</h2>
+    const enrichedWinners: WinnerWithDetails[] = await Promise.all(
+      winners.map(async (winner) => ({
+        ...winner,
+        car: await getCar(winner.id),
+      }))
+    );
+
+    this.renderHeader(totalCount, page);
+    this.renderTable(enrichedWinners);
+    this.updatePaginationButtons();
+  }
+
+  private renderHeader(total: string, page: number): void {
+    this.titleEl.textContent = `Winners (${total})`;
+    this.pageEl.textContent = `Page #${page}`;
+  }
+
+  private renderTable(winners: WinnerWithDetails[]): void {
+    this.tableContainer.innerHTML = "";
+    const table = document.createElement("table");
+    table.className = "winners-table";
+
+    table.innerHTML = `
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Car Image</th>
+          <th>Name</th>
+          <th class="sortable ${this.sortBy === "wins" ? "active" : ""}" data-sort="wins">
+            Wins ${this.getSortIcon("wins")}
+          </th>
+          <th class="sortable ${this.sortBy === "time" ? "active" : ""}" data-sort="time">
+            Best Time (s) ${this.getSortIcon("time")}
+          </th>
+        </tr>
+      </thead>
+      <tbody id="winners-body"></tbody>
     `;
+
+    this.renderRows(table.querySelector("#winners-body")!, winners);
+    this.initSortListeners(table);
+    this.tableContainer.append(table);
+  }
+
+  private renderRows(tbody: HTMLElement, winners: WinnerWithDetails[]): void {
+    let index = 0;
+    for (const winner of winners) {
+      const row = document.createElement("tr");
+      const rowNumber = index + 1 + (state.winnersPage - 1) * WINNERS_PER_PAGE;
+
+      row.innerHTML = `
+        <td>${rowNumber}</td>
+        <td class="car-icon-cell"></td>
+        <td>${winner.car.name}</td>
+        <td>${winner.wins}</td>
+        <td>${winner.time}</td>
+      `;
+
+      const carIcon = new CarIcon(winner.car.color);
+      row.querySelector(".car-icon-cell")?.append(carIcon.getElement());
+
+      tbody.append(row);
+      index += 1;
+    }
+  }
+
+  private initSortListeners(table: HTMLTableElement): void {
+    const sortableHeaders = table.querySelectorAll<HTMLElement>(".sortable");
+    for (const header of sortableHeaders) {
+      header.addEventListener("click", () => {
+        const type = header.dataset.sort as "id" | "wins" | "time";
+        this.toggleSort(type);
+      });
+    }
+  }
+
+  private updatePaginationButtons(): void {
+    const isFirstPage = state.winnersPage <= 1;
+    const isLastPage = state.winnersPage * WINNERS_PER_PAGE >= this.totalCount;
+
+    (this.prevBtn.getElement() as HTMLButtonElement).disabled = isFirstPage;
+    (this.nextBtn.getElement() as HTMLButtonElement).disabled = isLastPage;
+  }
+
+  private async handlePageChange(delta: number): Promise<void> {
+    state.winnersPage += delta;
+    await this.loadData();
+  }
+
+  private toggleSort(type: "id" | "wins" | "time"): void {
+    if (this.sortBy === type) {
+      this.sortOrder = this.sortOrder === "ASC" ? "DESC" : "ASC";
+    } else {
+      this.sortBy = type;
+      this.sortOrder = "ASC";
+    }
+    void this.loadData();
+  }
+
+  private getSortIcon(target: string): string {
+    if (this.sortBy !== target) return "↕";
+    return this.sortOrder === "ASC" ? "↑" : "↓";
   }
 }


### PR DESCRIPTION
## Related Issue
Closes #32 

> Link this Pull Request to a GitHub Issue from the Project board.
> Use `Closes #<issue-number>` to automatically close the task after merge.

---

## Description
What does this PR change?

This PR implements the Winners View table. It introduces a high-quality, data-enriched table that combines winner statistics with garage car details.
---

## Type of change
- [x] Data Enrichment: Implemented logic to fetch the winners list from GET /winners and concurrently resolve car names and colors via GET /garage/:id.
- [x] Advanced Sorting: Added server-side sorting for "Wins" and "Best Time" using dynamic API query parameters.
- [x] State Management: Connected the view to state.winnersPage to satisfy requirements for persistent view state.
---

## Checklist
- [x] Fetch winners list from GET /winners
- [x] For each winner, fetch car info from garage (GET /garage/:id) to display name and color/image
- [x] Table includes: number, car preview, name, wins, best time
- [x] Shows total winners count + page number

## Additional notes
