### PR TITLE
feat: implement winner update flow after race completion

### DIFF
--- a/src/api/winners.ts
+++ b/src/api/winners.ts
@@ -21,3 +21,33 @@ export const getWinners = async (
     totalCount: response.headers.get("X-Total-Count") || "0",
   };
 };
+
+export const getWinner = async (id: number) => {
+  const response = await fetch(`${BASE_URL}/winners/${id}`);
+  return response.ok ? await response.json() : undefined;
+};
+
+export const createWinner = async (winner: {
+  id: number;
+  wins: number;
+  time: number;
+}) => {
+  const response = await fetch(`${BASE_URL}/winners`, {
+    method: "POST",
+    body: JSON.stringify(winner),
+    headers: { "Content-Type": "application/json" },
+  });
+  return response;
+};
+
+export const updateWinner = async (
+  id: number,
+  winner: { wins: number; time: number }
+) => {
+  const response = await fetch(`${BASE_URL}/winners/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(winner),
+    headers: { "Content-Type": "application/json" },
+  });
+  return response;
+};

--- a/src/utils/save-race-winner.ts
+++ b/src/utils/save-race-winner.ts
@@ -1,0 +1,34 @@
+import { getWinner, createWinner, updateWinner } from "../api/winners";
+
+const ERROR_NUMBER = 500;
+
+export const updateWinnerAfterRace = async (
+  id: number,
+  time: number
+): Promise<void> => {
+  try {
+    const existingWinner = await getWinner(id);
+
+    if (existingWinner) {
+      await updateWinner(id, {
+        wins: existingWinner.wins + 1,
+        time: Math.min(existingWinner.time, time),
+      });
+    } else {
+      const response = await createWinner({ id, wins: 1, time });
+
+      if (response.status === ERROR_NUMBER) {
+        throw new Error("Duplicate ID");
+      }
+    }
+  } catch (error) {
+    const latestData = await getWinner(id);
+    console.log(error);
+    if (latestData) {
+      await updateWinner(id, {
+        wins: latestData.wins + 1,
+        time: Math.min(latestData.time, time),
+      });
+    }
+  }
+};


### PR DESCRIPTION
## Related Issue
Closes #35 

> Link this Pull Request to a GitHub Issue from the Project board.
> Use `Closes #<issue-number>` to automatically close the task after merge.

---

## Description
What does this PR change?

This PR implements the automated update of the winners database following the conclusion of a race.
---

## Type of change
- [x] API Expansion: Added getWinner, createWinner, and updateWinner methods to the winners API module.
- [x] Upsert Flow: Created a centralized saveRaceWinner function that handles the logic of checking existing records before deciding to POST or PUT.
- [x] Best Time Logic: Added logic to ensure the time field always reflects the winner's best performance (the minimum value between the previous record and the new race time).
- [x] Error Handling: Designed the flow to gracefully handle the "duplicate ID" error by checking existence first.
---

## Checklist
- [x] If winner not exists: POST /winners with { id, wins: 1, time }
- [x] If winner exists: PUT /winners/:id with updated wins and best time
- [x] Handles duplicate insert error (500 “duplicate id”) by fallback to update flow


## Additional notes
